### PR TITLE
`Assert-BlockString`: Allow string array and single string for `Expected`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,3 +13,5 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Updated README.md
+- `Assert-BlockString`
+  - Allow it to pass string array and single string to `Expected` parameter.

--- a/source/Public/Assert-BlockString.ps1
+++ b/source/Public/Assert-BlockString.ps1
@@ -57,7 +57,6 @@ function Assert-BlockString
         $Actual,
 
         [Parameter(Position = 0, Mandatory = $true)]
-        [System.String[]]
         $Expected,
 
         [Parameter()]
@@ -77,19 +76,25 @@ function Assert-BlockString
     }
 
     # Verify if $Actual is a string or string array
-    $isStringType = $Actual -is [System.String] -or ($Actual -is [System.Array] -and $Actual[0] -is [System.String])
+    $isActualStringType = $Actual -is [System.String] -or ($Actual -is [System.Array] -and ($Actual.Count -eq 0 -or ($Actual.Count -gt 0 -and $Actual[0] -is [System.String])))
 
-    $stringsAreEqual = $isStringType -and (-join $Actual) -ceq (-join $Expected)
+    $isExpectedStringType = $Expected -is [System.String] -or ($Expected -is [System.Array] -and ($Expected.Count -eq 0 -or ($Expected.Count -gt 0 -and $Expected[0] -is [System.String])))
+
+    $stringsAreEqual = $isActualStringType -and $isExpectedStringType -and (-join $Actual) -ceq (-join $Expected)
 
     if (-not $stringsAreEqual)
     {
-        if (-not $isStringType)
+        if (-not $isActualStringType)
         {
-            $message = 'Expected to actual value to be of type string or string[], but it was not.'
+            $message = 'The Actual value must be of type string or string[], but it was not.'
+        }
+        elseif (-not $isExpectedStringType)
+        {
+            $message = 'The Expected value must be of type string or string[], but it was not.'
         }
         else
         {
-            $message = 'Expect the strings to be equal'
+            $message = 'Expected the strings to be equal'
 
             if ($Because)
             {

--- a/tests/Unit/Public/Assert-BlockString.tests.ps1
+++ b/tests/Unit/Public/Assert-BlockString.tests.ps1
@@ -91,6 +91,46 @@ Describe 'Assert-BlockString' {
         { & $scriptBlock } | Should -Not -Throw
     }
 
+    It 'Should be able to pass empty collection as Expected' {
+        $mockExpected = 'Test string'
+
+        $scriptBlock = {
+            '' | Assert-BlockString -Expected @()
+        }
+
+        { & $scriptBlock } | Should -Not -Throw
+    }
+
+    It 'Should be able to pass empty string as Expected' {
+        $mockExpected = 'Test string'
+
+        $scriptBlock = {
+            '' | Assert-BlockString -Expected ''
+        }
+
+        { & $scriptBlock } | Should -Not -Throw
+    }
+
+    It 'Should be able to pass empty collection as Actual' {
+        $mockExpected = 'Test string'
+
+        $scriptBlock = {
+            Assert-BlockString -Actual @() -Expected @()
+        }
+
+        { & $scriptBlock } | Should -Not -Throw
+    }
+
+    It 'Should be able to pass empty string as Actual' {
+        $mockExpected = 'Test string'
+
+        $scriptBlock = {
+            Assert-BlockString -Actual '' -Expected ''
+        }
+
+        { & $scriptBlock } | Should -Not -Throw
+    }
+
     It 'Should be able to be called using its alias' {
         $mockExpected = 'Test string'
 
@@ -99,5 +139,29 @@ Describe 'Assert-BlockString' {
         }
 
         { & $scriptBlock } | Should -Not -Throw
+    }
+
+    It 'Should throw the correct error message when Actual is not a string' {
+        $mockExpected = 'Test string'
+
+        $scriptBlock = {
+            ([Int32] -1) | Should-BeBlockString -Expected $mockExpected
+        }
+
+        { & $scriptBlock } | Should -Throw -ExpectedMessage 'The Actual value must be of type string or string`[`], but it was not.'
+    }
+
+    It 'Should throw the correct error message when Expected is not a string' {
+        $mockActual = 'Test string'
+
+        $scriptBlock = {
+            'Test string' | Should-BeBlockString -Expected ([Int32] -1)
+        }
+
+        { & $scriptBlock } | Should-Throw -ExceptionMessage 'The Expected value must be of type string or string`[`], but it was not.'
+    }
+
+    It 'Should throw the correct error message when Expected is not a string' {
+        { throw 'int[]' } | Should-Throw -ExceptionMessage 'string`[`]'
     }
 }

--- a/tests/Unit/Public/Assert-BlockString.tests.ps1
+++ b/tests/Unit/Public/Assert-BlockString.tests.ps1
@@ -160,8 +160,4 @@ Describe 'Assert-BlockString' {
 
         { & $scriptBlock } | Should-Throw -ExceptionMessage 'The Expected value must be of type string or string`[`], but it was not.'
     }
-
-    It 'Should throw the correct error message when Expected is not a string' {
-        { throw 'int[]' } | Should-Throw -ExceptionMessage 'string`[`]'
-    }
 }


### PR DESCRIPTION

#### Pull Request (PR) description
- `Assert-BlockString`
  - Allow it to pass string array and single string to `Expected` parameter.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md and source/WikiSource.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Viscalyx.Assert/3)
<!-- Reviewable:end -->
