### PR TITLE
Update `Assert-BlockString` to use `Out-Difference`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,3 +15,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Updated README.md
 - `Assert-BlockString`
   - Allow it to pass string array and single string to `Expected` parameter.
+  - Update to use `Out-Difference`.

--- a/source/Public/Assert-BlockString.ps1
+++ b/source/Public/Assert-BlockString.ps1
@@ -21,7 +21,7 @@
     .PARAMETER Because
         An optional reason or explanation for the assertion.
 
-    .PARAMETER DifferenceAnsi
+    .PARAMETER Highlight
         An optional ANSI color code to highlight the difference between the expected
         and actual strings. The default value is '31m' (red text).
 
@@ -65,7 +65,7 @@ function Assert-BlockString
 
         [Parameter()]
         [System.String]
-        $DifferenceAnsi = '31m'
+        $Highlight = '31m'
     )
 
     $hasPipelineInput = $MyInvocation.ExpectingInput
@@ -101,10 +101,10 @@ function Assert-BlockString
                 $message += " because $Because"
             }
 
-            $message += ", but they were not. Difference is highlighted:`r`n"
+            $message += ", but they were not. Difference is highlighted:`r`n "
 
-            $message += Out-Diff -Reference $Expected -Difference $Actual -ReferenceLabel 'Expected' -DifferenceLabel 'Actual' -DifferenceAnsi:$DifferenceAnsi -PassThru |
-                ForEach-Object { "`e[0m$_`r`n" }
+            $message += Out-Difference -Reference $Expected -Difference $Actual -ReferenceLabel 'Expected:' -DifferenceLabel 'But was:' -HighlightStart:$Highlight |
+                ForEach-Object -Process { "`e[0m$_`r`n" }
         }
 
         throw [Pester.Factory]::CreateShouldErrorRecord($Message, $MyInvocation.ScriptName, $MyInvocation.ScriptLineNumber, $MyInvocation.Line.TrimEnd([System.Environment]::NewLine), $true)


### PR DESCRIPTION

#### Pull Request (PR) description
- `Assert-BlockString`
  - Update to use `Out-Difference`.

#### This Pull Request (PR) fixes the following issues
None.

#### Task list
<!--
    To aid community reviewers in reviewing and merging your PR, please take
    the time to run through the below checklist and make sure your PR has
    everything updated as required.

    Change to [x] for each task in the task list that applies to your PR.
    For those task that don't apply to you PR, leave those unchecked.
-->
- [x] Added an entry to the change log under the Unreleased section of the
      file CHANGELOG.md. Entry should say what was changed and how that
      affects users (if applicable), and reference the issue being resolved
      (if applicable).
- [ ] Documentation added/updated in README.md and source/WikiSource.
- [ ] Comment-based help added/updated for all new/changed functions.
- [ ] Localization strings added/updated in all localization files as appropriate.
- [ ] Examples appropriately added/updated.
- [x] Unit tests added/updated. See [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [ ] Integration tests added/updated (where applicable). See
  [DSC Community Testing Guidelines](https://dsccommunity.org/guidelines/testing-guidelines).
- [x] New/changed code adheres to [DSC Community Style Guidelines](https://dsccommunity.org/styleguidelines).

<!-- Reviewable:start -->
- - -
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/viscalyx/Viscalyx.Assert/4)
<!-- Reviewable:end -->
